### PR TITLE
Add exports.types key to package.json

### DIFF
--- a/.changeset/afraid-swans-breathe.md
+++ b/.changeset/afraid-swans-breathe.md
@@ -1,0 +1,5 @@
+---
+"pretty-cache-header": patch
+---
+
+Add exports.types key to package.json

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "sideEffects": false,
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Types discovery was not working in my project where I have `"moduleResolution": "nodenext"` set. Adding this proposed change fixed it in my case.